### PR TITLE
Поправлена ошибка при просмотре многофайловых торрентов через libtorrent...

### DIFF
--- a/src/xbmcup/net.py
+++ b/src/xbmcup/net.py
@@ -744,7 +744,8 @@ class LibTorrent:
                 progress.close()
                 return self._end()
         progress.close()
-        
+
+        xbmcvfs.rename(self._filename, self._filename)        
         if info:
             info['size'] = selfile.size
             xbmc.Player().play(self._filename.encode('utf8'), info)


### PR DESCRIPTION
Пример: Если в торренте содержалось два файла 1.avi и 2.avi
После просмотра 1.avi нельзя сразу начать просматривать файл 2.avi
Возникала ошибка CDVDPlayer::OpenInputStream - error opening
